### PR TITLE
Only scroll web console to the bottom if previously at the bottom

### DIFF
--- a/web/static/js/web_console.js
+++ b/web/static/js/web_console.js
@@ -6,11 +6,26 @@ export default class WebConsole {
   }
 
   log(msg) {
-    var list = this.list;
+    var wasScrolledToTheBottom = isScrolledToTheBottom();
+    addLine(msg);
+    if (wasScrolledToTheBottom) {
+      scrollToTheBottom();
+    }
+  }
+  
+  addLine(msg) {
     var li = document.createElement("li");
     var text = document.createTextNode(msg);
     li.appendChild(text);
-    list.appendChild(li);
-    list.scrollTop = list.scrollHeight;
+    this.list.appendChild(li);
+  }
+  
+  isScrolledToTheBottom() {
+    var list = this.list;
+    return list.scrollTop >= list.scrollHeight - list.clientHeight;
+  }
+  
+  scrollToTheBottom() {
+    this.list.scrollTop = this.list.scrollHeight;
   }
 }

--- a/web/static/js/web_console.js
+++ b/web/static/js/web_console.js
@@ -21,8 +21,7 @@ export default class WebConsole {
   }
   
   isScrolledToTheBottom() {
-    var list = this.list;
-    return list.scrollTop >= list.scrollHeight - list.clientHeight;
+    return this.list.scrollTop >= this.list.scrollHeight - this.list.clientHeight;
   }
   
   scrollToTheBottom() {


### PR DESCRIPTION
This allows the user to scroll back and read the console at their leisure, even if the console keeps getting new “Requesting content.” messages. If the user scrolls back to the bottom, the console will once again keep itself at the bottom when new messages are added.

I haven’t tested this change on the actual page. The only testing I did was playing around with the `scrollTop`, `scrollHeight` and `clientHeight` properties in the Web Console to figure out how to implement `isScrolledToTheBottom`.
